### PR TITLE
v0.1.5: Remove CAT

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: twistR
 Title: TWIST (Triangulation WIthin A STudy) analysis in R.
-Version: 0.1.4.9000
+Version: 0.1.5
 Authors@R: c(person("Luke", "Pilling", 
                     email = "L.Pilling@exeter.ac.uk", 
                     role = c("aut", "cre"),
@@ -15,4 +15,4 @@ URL: https://lcpilling.github.io/twistR, https://github.com/lcpilling/twistR
 Depends: R (>= 3.5.0), margins (>= 0.3.26), timereg (>= 2.0.0)
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Change URL to reflect my GitHub username change from `lukepilling` to `lcpilling` to be more consistent between different logins, websites, and social media
  - https://lcpilling.github.io/twistR
  - https://github.com/lcpilling/twistR
+* Change CAT analysis to optional (default is FALSE) -- slow and not often used
 
 
 # twistR 0.1.4

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# twistR 0.1.4.9000 (6 June 2024)
+# twistR 0.1.5 (5 Feb 2025)
 
 ### Changes
 * Change URL to reflect my GitHub username change from `lukepilling` to `lcpilling` to be more consistent between different logins, websites, and social media

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,28 +2,28 @@
 
 ### Changes
 * Change URL to reflect my GitHub username change from `lukepilling` to `lcpilling` to be more consistent between different logins, websites, and social media
- - https://lcpilling.github.io/twistR
- - https://github.com/lcpilling/twistR
+  * https://lcpilling.github.io/twistR
+  * https://github.com/lcpilling/twistR
 * Change CAT analysis to optional (default is FALSE) -- slow and not often used
+  * Knock-on changes to gmte_plot
 
-
-# twistR 0.1.4
+# twistR 0.1.4 (10 Feb 2023)
 
 * `FullCombined` object is now a data.frame with a column for "Model" rather than using rownames of a matrix
 * New function `gmte_plot()` creates a forest plot of estimates when provided with a `twistR_GMTE` object
 
-# twistR 0.1.3
+# twistR 0.1.3 (9 Feb 2022)
 
 * Fix bug with gmte_combine where function fails if CAT estimate doesn't converge - allows returning of GMTE (etc) even if failure of one estimate
 
-# twistR 0.1.2
+# twistR 0.1.2 (26 Jan 2022)
 
 * Add 'verbose' option to help with error checking/debugging, or if the user simply wants lots of output.
 
-# twistR 0.1.1
+# twistR 0.1.1 (12 Oct 2021)
 
 * Update calculation of Tshat to use linear regression model throughout. Allows use of multi-allelic genetic variants.
 
-# twistR 0.1.0
+# twistR 0.1.0 (16 Sept 2021)
 
 * First release of package.

--- a/R/gmte_aalen.R
+++ b/R/gmte_aalen.R
@@ -37,7 +37,9 @@
 gmte_aalen = function(Y_t0,Y_t1,Y_d,T,G,Z,D,Nsim=100,alpha=0.05,doCAT=FALSE,verbose=FALSE)
 {
 	start_time = Sys.time()
-	cat("TWIST (Triangulation WIthin A STudy) analysis in R - Aalen additive hazards (time-to-event) model\n")
+	v <- packageVersion("twistR")
+	cat(paste0("TWIST (Triangulation WIthin A STudy) analysis in R v", v, "\n"))
+	cat("- Aalen additive hazards model (time-to-event outcome)\n\n")
 	require(timereg)
 
 	## check inputs
@@ -81,6 +83,7 @@ gmte_aalen = function(Y_t0,Y_t1,Y_d,T,G,Z,D,Nsim=100,alpha=0.05,doCAT=FALSE,verb
 		if (! Zx %in% colnames(D))  stop(paste0("Covariate [", Zx, "] needs to be in data.frame D"))
 	}
 
+	cat("Parameters:\n")
 	cat(paste0("- Outcome Y_t0 [", Y_t0, "] i.e. when participants enter model\n"))
 	cat(paste0("- Outcome Y_t1 [", Y_t1, "] i.e. when participants exit model\n"))
 	cat(paste0("- Outcome Y_d [", Y_d, "] i.e. binary variable indicating event\n"))

--- a/R/gmte_aalen.R
+++ b/R/gmte_aalen.R
@@ -11,6 +11,7 @@
 #' @param D A data.frame containing the above variables.
 #' @param Nsim Number of simulations to perform in the \code{aalen()} models. Default is 100.
 #' @param alpha The p-value threshold for the chi-square test, estimating whether two estimates should be combined. Default is 0.05.
+#' @param doCAT Run the CAT analysis? Default is FALSE.
 #' @param verbose Return lots of output - useful for error checking. Default is FALSE.
 #' @return An object of class \code{twistR_GMTE} containing the following components:\describe{
 #' \item{\code{CAT}}{The summary statistics from the Corrected As Treated (CAT) analysis.}
@@ -33,7 +34,7 @@
 #' Z="age+PC1+PC2+PC3+PC4+PC5+PC6+PC7+PC8+PC9+PC10"
 #' results=gmte_aalen(Y_t0,Y_t1,Y_d,T,G,Z,D)
 
-gmte_aalen = function(Y_t0,Y_t1,Y_d,T,G,Z,D,Nsim=100,alpha=0.05,verbose=FALSE)
+gmte_aalen = function(Y_t0,Y_t1,Y_d,T,G,Z,D,Nsim=100,alpha=0.05,doCAT=FALSE,verbose=FALSE)
 {
 	start_time = Sys.time()
 	cat("TWIST (Triangulation WIthin A STudy) analysis in R - Aalen additive hazards (time-to-event) model\n")
@@ -82,7 +83,7 @@ gmte_aalen = function(Y_t0,Y_t1,Y_d,T,G,Z,D,Nsim=100,alpha=0.05,verbose=FALSE)
 
 	cat(paste0("- Outcome Y_t0 [", Y_t0, "] i.e. when participants enter model\n"))
 	cat(paste0("- Outcome Y_t1 [", Y_t1, "] i.e. when participants exit model\n"))
-	cat(paste0("- Outcome Y_t0 [", Y_d, "] i.e. binary variable indicating event\n"))
+	cat(paste0("- Outcome Y_d [", Y_d, "] i.e. binary variable indicating event\n"))
 	cat(paste0("- Treatment T [", T, "]\n"))
 	cat(paste0("- Genotype G [", G, "]\n"))
 	cat(paste0("- Covariates [", Zwrapped, "]\n"))
@@ -146,13 +147,17 @@ gmte_aalen = function(Y_t0,Y_t1,Y_d,T,G,Z,D,Nsim=100,alpha=0.05,verbose=FALSE)
 	survival_object = Surv(D[,"Y_t0"],D[,"Y_t1"],D[,"Y_d"])
 
 	# Corrected-As treated (CAT)
-	cat("Run CAT model\n")
-	D[,"Tcat"] = D[,"T"]*mean(D[,"G"][D[,"T"]==1])
-	CATfit     = invisible(aalen(as.formula(paste0("survival_object~const(Tcat)+",Zwrapped)),data=D,n.sim=Nsim))
-	CAT        = coef(CATfit)["const(Tcat)",1]
-	sCAT       = coef(CATfit)["const(Tcat)",2]
-	pCAT       = coef(CATfit)["const(Tcat)",5]
-	if (verbose)  print(CATfit)
+	if (doCAT)  {
+		cat("Run CAT model\n")
+		D[,"Tcat"] = D[,"T"]*mean(D[,"G"][D[,"T"]==1])
+		CATfit     = invisible(aalen(as.formula(paste0("survival_object~const(Tcat)+",Zwrapped)),data=D,n.sim=Nsim))
+		CAT        = coef(CATfit)["const(Tcat)",1]
+		sCAT       = coef(CATfit)["const(Tcat)",2]
+		pCAT       = coef(CATfit)["const(Tcat)",5]
+		if (verbose)  print(CATfit)
+	} else {
+		pCAT <- sCAT <- CAT <- CATfit <- NA
+	}
 
 	# GMTE(0)
 	cat("Run GMTE(0) model\n")
@@ -199,6 +204,7 @@ gmte_aalen = function(Y_t0,Y_t1,Y_d,T,G,Z,D,Nsim=100,alpha=0.05,verbose=FALSE)
 		FullCombined[5,]  = c(MR,sMR,pMR)
 		colnames(FullCombined) = c("Est","SE","EstP")
 		rownames(FullCombined) = c("CAT","GMTE0","GMTE1","RGMTE","MR")
+		if (!doCAT)  FullCombined <- FullCombined[2:5,]
 		cat("\nResults (initial):\n")
 		print(FullCombined)
 	}
@@ -207,14 +213,16 @@ gmte_aalen = function(Y_t0,Y_t1,Y_d,T,G,Z,D,Nsim=100,alpha=0.05,verbose=FALSE)
 	cat("Combined methods\n")
 	Ests         = c(MR,RGMTE); SEs = c(sMR,sRGMTE)
 	RGMTE_MR     = gmte_combine(Ests,SEs,alpha)
-	Ests         = c(CAT,RGMTE); SEs = c(sCAT,sRGMTE)
-	RGMTE_CAT    = gmte_combine(Ests,SEs,alpha)
-	Ests         = c(CAT,MR); SEs = c(sCAT,sMR)
-	MR_CAT       = gmte_combine(Ests,SEs,alpha)
-	Ests         = c(CAT,GMTE1); SEs = c(sCAT,sGMTE1)
-	GMTE1_CAT    = gmte_combine(Ests,SEs,alpha)
-	Ests         = c(MR,RGMTE,CAT); SEs = c(sMR,sRGMTE,sCAT)
-	RGMTE_MR_CAT = gmte_combine(Ests,SEs,alpha)
+	if (doCAT)  {
+		Ests         = c(CAT,RGMTE); SEs = c(sCAT,sRGMTE)
+		RGMTE_CAT    = gmte_combine(Ests,SEs,alpha)
+		Ests         = c(CAT,MR); SEs = c(sCAT,sMR)
+		MR_CAT       = gmte_combine(Ests,SEs,alpha)
+		Ests         = c(CAT,GMTE1); SEs = c(sCAT,sGMTE1)
+		GMTE1_CAT    = gmte_combine(Ests,SEs,alpha)
+		Ests         = c(MR,RGMTE,CAT); SEs = c(sMR,sRGMTE,sCAT)
+		RGMTE_MR_CAT = gmte_combine(Ests,SEs,alpha)
+	}
 
 	# Final output
 	FullCombined      = matrix(nrow=10,ncol=6)
@@ -224,13 +232,17 @@ gmte_aalen = function(Y_t0,Y_t1,Y_d,T,G,Z,D,Nsim=100,alpha=0.05,verbose=FALSE)
 	FullCombined[4,]  = c(RGMTE,sRGMTE,pRGMTE,NA,NA,NA)
 	FullCombined[5,]  = c(MR,sMR,pMR,NA,NA,NA)
 	FullCombined[6,]  = RGMTE_MR
-	FullCombined[7,]  = RGMTE_CAT
-	FullCombined[8,]  = MR_CAT
-	FullCombined[9,]  = GMTE1_CAT
-	FullCombined[10,] = RGMTE_MR_CAT
+	if (doCAT)  {
+		FullCombined[7,]  = RGMTE_CAT
+		FullCombined[8,]  = MR_CAT
+		FullCombined[9,]  = GMTE1_CAT
+		FullCombined[10,] = RGMTE_MR_CAT
+	}
 
 	colnames(FullCombined) = c("Est","SE","EstP","Qstat","Qp","Combine?")
 	FullCombined = cbind(Model=c("CAT","GMTE0","GMTE1","RGMTE","MR","RGMTE_MR","RGMTE_CAT","MR_CAT","GMTE1_CAT","RGMTE_MR_CAT"), as.data.frame(FullCombined))
+
+	if (!doCAT)  FullCombined <- FullCombined[2:6,]
 
 	cat("\nResults:\n")
 	print(FullCombined)

--- a/R/gmte_aalen.R
+++ b/R/gmte_aalen.R
@@ -37,10 +37,13 @@
 gmte_aalen = function(Y_t0,Y_t1,Y_d,T,G,Z,D,Nsim=100,alpha=0.05,doCAT=FALSE,verbose=FALSE)
 {
 	start_time = Sys.time()
+
+	require(timereg)
+	require(survival)
+
 	v <- packageVersion("twistR")
 	cat(paste0("TWIST (Triangulation WIthin A STudy) analysis in R v", v, "\n"))
 	cat("- Aalen additive hazards model (time-to-event outcome)\n\n")
-	require(timereg)
 
 	## check inputs
 	if (class(Y_t0) != "character")  stop("Outcome Y_t0 needs to be a variable name i.e. a string (class `character`)")

--- a/R/gmte_binary.R
+++ b/R/gmte_binary.R
@@ -36,7 +36,7 @@ gmte_binary = function(Y,T,G,Z,D,Link="logit",alpha=0.05,doCAT=FALSE,verbose=FAL
 	start_time = Sys.time()
 	v <- packageVersion("twistR")
 	cat(paste0("TWIST (Triangulation WIthin A STudy) analysis in R v", v, "\n"))
-	cat("- Logistic model (binary outcome)\n")
+	cat("- Logistic model (binary outcome)\n\n")
 	require(margins)
 
 	## check inputs
@@ -54,6 +54,7 @@ gmte_binary = function(Y,T,G,Z,D,Link="logit",alpha=0.05,doCAT=FALSE,verbose=FAL
 	Zs=strsplit(Z,"[+]|[*]")[[1]]
 	for (Zx in Zs)  if (! Zx %in% colnames(D))  stop(paste0("Covariate [", Zx, "] needs to be in data.frame D"))
 
+	cat("Parameters:\n")
 	cat(paste0("- Outcome Y [", Y, "]\n"))
 	cat(paste0("- Treatment T [", T, "]\n"))
 	cat(paste0("- Genotype G [", G, "]\n"))

--- a/R/gmte_binary.R
+++ b/R/gmte_binary.R
@@ -34,7 +34,9 @@
 gmte_binary = function(Y,T,G,Z,D,Link="logit",alpha=0.05,doCAT=FALSE,verbose=FALSE)
 {
 	start_time = Sys.time()
-	cat("TWIST (Triangulation WIthin A STudy) analysis in R - binary outcome\n")
+	v <- packageVersion("twistR")
+	cat(paste0("TWIST (Triangulation WIthin A STudy) analysis in R v", v, "\n"))
+	cat("- Logistic model (binary outcome)\n")
 	require(margins)
 
 	## check inputs

--- a/R/gmte_binary.R
+++ b/R/gmte_binary.R
@@ -34,10 +34,12 @@
 gmte_binary = function(Y,T,G,Z,D,Link="logit",alpha=0.05,doCAT=FALSE,verbose=FALSE)
 {
 	start_time = Sys.time()
+
+	require(margins)
+
 	v <- packageVersion("twistR")
 	cat(paste0("TWIST (Triangulation WIthin A STudy) analysis in R v", v, "\n"))
 	cat("- Logistic model (binary outcome)\n\n")
-	require(margins)
 
 	## check inputs
 	if (class(Y) != "character")  stop("Outcome Y needs to be a variable name i.e. a string (class `character`)")

--- a/R/gmte_binary.R
+++ b/R/gmte_binary.R
@@ -9,6 +9,7 @@
 #' @param D A data.frame containing the above variables.
 #' @param Link Link function for the \code{glm()} - needs to be one of "logit","probit" or "identity". If unspecified the default is "logit".
 #' @param alpha The p-value threshold for the chi-square test, estimating whether two estimates should be combined. Default is 0.05.
+#' @param doCAT Run the CAT analysis? Default is FALSE.
 #' @param verbose Return lots of output - useful for error checking. Default is FALSE.
 #' @return An object of class \code{twistR_GMTE} containing the following components:\describe{
 #' \item{\code{CAT}}{The summary statistics from the Corrected As Treated (CAT) analysis.}
@@ -30,7 +31,7 @@
 #' Link="logit"
 #' results=gmte_binary(Y,T,G,Z,D,Link)
 
-gmte_binary = function(Y,T,G,Z,D,Link="logit",alpha=0.05,verbose=FALSE)
+gmte_binary = function(Y,T,G,Z,D,Link="logit",alpha=0.05,doCAT=FALSE,verbose=FALSE)
 {
 	start_time = Sys.time()
 	cat("TWIST (Triangulation WIthin A STudy) analysis in R - binary outcome\n")
@@ -102,14 +103,18 @@ gmte_binary = function(Y,T,G,Z,D,Link="logit",alpha=0.05,verbose=FALSE)
 	####################
 
 	# Corrected-As treated (CAT)
-	cat("Run CAT model\n")
-	D[,"Tcat"] = D[,"T"]*mean(D[,"G"][D[,"T"]==1])
-	CATfit     = glm(as.formula(paste0("Y~Tcat+",Z)),family=binomial(link=Link),data=D)
-	MarCAT     = summary(margins(CATfit))
-	CAT        = MarCAT[MarCAT[,"factor"]=="Tcat",2]
-	sCAT       = MarCAT[MarCAT[,"factor"]=="Tcat",3]
-	pCAT       = MarCAT[MarCAT[,"factor"]=="Tcat",5]
-	if (verbose)  print(CATfit)
+	if (doCAT)  {
+		cat("Run CAT model\n")
+		D[,"Tcat"] = D[,"T"]*mean(D[,"G"][D[,"T"]==1])
+		CATfit     = glm(as.formula(paste0("Y~Tcat+",Z)),family=binomial(link=Link),data=D)
+		MarCAT     = summary(margins(CATfit))
+		CAT        = MarCAT[MarCAT[,"factor"]=="Tcat",2]
+		sCAT       = MarCAT[MarCAT[,"factor"]=="Tcat",3]
+		pCAT       = MarCAT[MarCAT[,"factor"]=="Tcat",5]
+		if (verbose)  print(CATfit)
+	} else {
+		pCAT <- sCAT <- CAT <- CATfit <- NA
+	}
 
 	# GMTE(0)
 	cat("Run GMTE(0) model\n")
@@ -160,6 +165,7 @@ gmte_binary = function(Y,T,G,Z,D,Link="logit",alpha=0.05,verbose=FALSE)
 		FullCombined[5,]  = c(MR,sMR,pMR)
 		colnames(FullCombined) = c("Est","SE","EstP")
 		rownames(FullCombined) = c("CAT","GMTE0","GMTE1","RGMTE","MR")
+		if (!doCAT)  FullCombined <- FullCombined[2:5,]
 		cat("\nResults (initial):\n")
 		print(FullCombined)
 	}
@@ -168,14 +174,16 @@ gmte_binary = function(Y,T,G,Z,D,Link="logit",alpha=0.05,verbose=FALSE)
 	cat("Combined methods\n")
 	Ests         = c(MR,RGMTE); SEs = c(sMR,sRGMTE)
 	RGMTE_MR     = gmte_combine(Ests,SEs,alpha)
-	Ests         = c(CAT,RGMTE); SEs = c(sCAT,sRGMTE)
-	RGMTE_CAT    = gmte_combine(Ests,SEs,alpha)
-	Ests         = c(CAT,MR); SEs = c(sCAT,sMR)
-	MR_CAT       = gmte_combine(Ests,SEs,alpha)
-	Ests         = c(CAT,GMTE1); SEs = c(sCAT,sGMTE1)
-	GMTE1_CAT    = gmte_combine(Ests,SEs,alpha)
-	Ests         = c(MR,RGMTE,CAT); SEs = c(sMR,sRGMTE,sCAT)
-	RGMTE_MR_CAT = gmte_combine(Ests,SEs,alpha)
+	if (doCAT)  {
+		Ests         = c(CAT,RGMTE); SEs = c(sCAT,sRGMTE)
+		RGMTE_CAT    = gmte_combine(Ests,SEs,alpha)
+		Ests         = c(CAT,MR); SEs = c(sCAT,sMR)
+		MR_CAT       = gmte_combine(Ests,SEs,alpha)
+		Ests         = c(CAT,GMTE1); SEs = c(sCAT,sGMTE1)
+		GMTE1_CAT    = gmte_combine(Ests,SEs,alpha)
+		Ests         = c(MR,RGMTE,CAT); SEs = c(sMR,sRGMTE,sCAT)
+		RGMTE_MR_CAT = gmte_combine(Ests,SEs,alpha)
+	}
 
 	# Final output
 	FullCombined      = matrix(nrow=10,ncol=6)
@@ -185,13 +193,17 @@ gmte_binary = function(Y,T,G,Z,D,Link="logit",alpha=0.05,verbose=FALSE)
 	FullCombined[4,]  = c(RGMTE,sRGMTE,pRGMTE,NA,NA,NA)
 	FullCombined[5,]  = c(MR,sMR,pMR,NA,NA,NA)
 	FullCombined[6,]  = RGMTE_MR
-	FullCombined[7,]  = RGMTE_CAT
-	FullCombined[8,]  = MR_CAT
-	FullCombined[9,]  = GMTE1_CAT
-	FullCombined[10,] = RGMTE_MR_CAT
+	if (doCAT)  {
+		FullCombined[7,]  = RGMTE_CAT
+		FullCombined[8,]  = MR_CAT
+		FullCombined[9,]  = GMTE1_CAT
+		FullCombined[10,] = RGMTE_MR_CAT
+	}
 
 	colnames(FullCombined) = c("Est","SE","EstP","Qstat","Qp","Combine?")
 	FullCombined = cbind(Model=c("CAT","GMTE0","GMTE1","RGMTE","MR","RGMTE_MR","RGMTE_CAT","MR_CAT","GMTE1_CAT","RGMTE_MR_CAT"), as.data.frame(FullCombined))
+
+	if (!doCAT)  FullCombined <- FullCombined[2:6,]
 
 	cat("\nResults:\n")
 	print(FullCombined)

--- a/R/gmte_continuous.R
+++ b/R/gmte_continuous.R
@@ -32,7 +32,9 @@
 gmte_continuous = function(Y,T,G,Z,D,alpha=0.05,doCAT=FALSE,verbose=FALSE)
 {
 	start_time = Sys.time()
-	cat("TWIST (Triangulation WIthin A STudy) analysis in R - continuous outcome\n")
+	v <- packageVersion("twistR")
+	cat(paste0("TWIST (Triangulation WIthin A STudy) analysis in R v", v, "\n"))
+	cat("- Linear model (continuous outcome)\n")
 
 	## check inputs
 	if (class(Y) != "character")  stop("Outcome Y needs to be a variable name i.e. a string (class `character`)")

--- a/R/gmte_continuous.R
+++ b/R/gmte_continuous.R
@@ -8,6 +8,7 @@
 #' @param Z A string containing the model covariates to appear in the \code{glm()} models (for example "age+sex"). All need to be in data.frame \code{D}.
 #' @param D A data.frame containing the above variables.
 #' @param alpha The p-value threshold for the chi-square test, estimating whether two estimates should be combined. Default is 0.05.
+#' @param doCAT Run the CAT analysis? Default is FALSE.
 #' @param verbose Return lots of output - useful for error checking. Default is FALSE.
 #' @return An object of class \code{twistR_GMTE} containing the following components:\describe{
 #' \item{\code{CAT}}{The summary statistics from the Corrected As Treated (CAT) analysis.}
@@ -28,7 +29,7 @@
 #' Z="age+PC1+PC2+PC3+PC4+PC5+PC6+PC7+PC8+PC9+PC10"
 #' results=gmte_continuous(Y,T,G,Z,D)
 
-gmte_continuous = function(Y,T,G,Z,D,alpha=0.05,verbose=FALSE)
+gmte_continuous = function(Y,T,G,Z,D,alpha=0.05,doCAT=FALSE,verbose=FALSE)
 {
 	start_time = Sys.time()
 	cat("TWIST (Triangulation WIthin A STudy) analysis in R - continuous outcome\n")
@@ -88,13 +89,17 @@ gmte_continuous = function(Y,T,G,Z,D,alpha=0.05,verbose=FALSE)
 	####################
 
 	# Corrected-As treated (CAT)
-	cat("Run CAT model\n")
-	D[,"Tcat"] = D[,"T"]*mean(D[,"G"][D[,"T"]==1])
-	CATfit     = lm(as.formula(paste0("Y~Tcat+",Z)),data=D)
-	CAT        = summary(CATfit)$coef["Tcat",1]
-	sCAT       = summary(CATfit)$coef["Tcat",2]
-	pCAT       = summary(CATfit)$coef["Tcat",4]
-	if (verbose)  print(CATfit)
+	if (doCAT)  {
+		cat("Run CAT model\n")
+		D[,"Tcat"] = D[,"T"]*mean(D[,"G"][D[,"T"]==1])
+		CATfit     = lm(as.formula(paste0("Y~Tcat+",Z)),data=D)
+		CAT        = summary(CATfit)$coef["Tcat",1]
+		sCAT       = summary(CATfit)$coef["Tcat",2]
+		pCAT       = summary(CATfit)$coef["Tcat",4]
+		if (verbose)  print(CATfit)
+	} else {
+		pCAT <- sCAT <- CAT <- CATfit <- NA
+	}
 
 	# GMTE(0)
 	cat("Run GMTE(0) model\n")
@@ -141,6 +146,7 @@ gmte_continuous = function(Y,T,G,Z,D,alpha=0.05,verbose=FALSE)
 		FullCombined[5,]  = c(MR,sMR,pMR)
 		colnames(FullCombined) = c("Est","SE","EstP")
 		rownames(FullCombined) = c("CAT","GMTE0","GMTE1","RGMTE","MR")
+		if (!doCAT)  FullCombined <- FullCombined[2:5,]
 		cat("\nResults (initial):\n")
 		print(FullCombined)
 	}
@@ -149,14 +155,16 @@ gmte_continuous = function(Y,T,G,Z,D,alpha=0.05,verbose=FALSE)
 	cat("Combined methods\n")
 	Ests         = c(MR,RGMTE); SEs = c(sMR,sRGMTE)
 	RGMTE_MR     = gmte_combine(Ests,SEs,alpha)
-	Ests         = c(CAT,RGMTE); SEs = c(sCAT,sRGMTE)
-	RGMTE_CAT    = gmte_combine(Ests,SEs,alpha)
-	Ests         = c(CAT,MR); SEs = c(sCAT,sMR)
-	MR_CAT       = gmte_combine(Ests,SEs,alpha)
-	Ests         = c(CAT,GMTE1); SEs = c(sCAT,sGMTE1)
-	GMTE1_CAT    = gmte_combine(Ests,SEs,alpha)
-	Ests         = c(MR,RGMTE,CAT); SEs = c(sMR,sRGMTE,sCAT)
-	RGMTE_MR_CAT = gmte_combine(Ests,SEs,alpha)
+	if (doCAT)  {
+		Ests         = c(CAT,RGMTE); SEs = c(sCAT,sRGMTE)
+		RGMTE_CAT    = gmte_combine(Ests,SEs,alpha)
+		Ests         = c(CAT,MR); SEs = c(sCAT,sMR)
+		MR_CAT       = gmte_combine(Ests,SEs,alpha)
+		Ests         = c(CAT,GMTE1); SEs = c(sCAT,sGMTE1)
+		GMTE1_CAT    = gmte_combine(Ests,SEs,alpha)
+		Ests         = c(MR,RGMTE,CAT); SEs = c(sMR,sRGMTE,sCAT)
+		RGMTE_MR_CAT = gmte_combine(Ests,SEs,alpha)
+	}
 
 	# Final output
 	FullCombined      = matrix(nrow=10,ncol=6)
@@ -166,13 +174,17 @@ gmte_continuous = function(Y,T,G,Z,D,alpha=0.05,verbose=FALSE)
 	FullCombined[4,]  = c(RGMTE,sRGMTE,pRGMTE,NA,NA,NA)
 	FullCombined[5,]  = c(MR,sMR,pMR,NA,NA,NA)
 	FullCombined[6,]  = RGMTE_MR
-	FullCombined[7,]  = RGMTE_CAT
-	FullCombined[8,]  = MR_CAT
-	FullCombined[9,]  = GMTE1_CAT
-	FullCombined[10,] = RGMTE_MR_CAT
+	if (doCAT)  {
+		FullCombined[7,]  = RGMTE_CAT
+		FullCombined[8,]  = MR_CAT
+		FullCombined[9,]  = GMTE1_CAT
+		FullCombined[10,] = RGMTE_MR_CAT
+	}
 
 	colnames(FullCombined) = c("Est","SE","EstP","Qstat","Qp","Combine?")
 	FullCombined = cbind(Model=c("CAT","GMTE0","GMTE1","RGMTE","MR","RGMTE_MR","RGMTE_CAT","MR_CAT","GMTE1_CAT","RGMTE_MR_CAT"), as.data.frame(FullCombined))
+
+	if (!doCAT)  FullCombined <- FullCombined[2:6,]
 
 	cat("\nResults:\n")
 	print(FullCombined)

--- a/R/gmte_continuous.R
+++ b/R/gmte_continuous.R
@@ -34,7 +34,7 @@ gmte_continuous = function(Y,T,G,Z,D,alpha=0.05,doCAT=FALSE,verbose=FALSE)
 	start_time = Sys.time()
 	v <- packageVersion("twistR")
 	cat(paste0("TWIST (Triangulation WIthin A STudy) analysis in R v", v, "\n"))
-	cat("- Linear model (continuous outcome)\n")
+	cat("- Linear model (continuous outcome)\n\n")
 
 	## check inputs
 	if (class(Y) != "character")  stop("Outcome Y needs to be a variable name i.e. a string (class `character`)")
@@ -49,6 +49,7 @@ gmte_continuous = function(Y,T,G,Z,D,alpha=0.05,doCAT=FALSE,verbose=FALSE)
 	Zs=strsplit(Z,"[+]|[*]")[[1]]
 	for (Zx in Zs)  if (! Zx %in% colnames(D))  stop(paste0("Covariate [", Zx, "] needs to be in data.frame D"))
 
+	cat("Parameters:\n")
 	cat(paste0("- Outcome Y [", Y, "]\n"))
 	cat(paste0("- Treatment T [", T, "]\n"))
 	cat(paste0("- Genotype G [", G, "]\n"))

--- a/R/gmte_continuous.R
+++ b/R/gmte_continuous.R
@@ -32,6 +32,7 @@
 gmte_continuous = function(Y,T,G,Z,D,alpha=0.05,doCAT=FALSE,verbose=FALSE)
 {
 	start_time = Sys.time()
+
 	v <- packageVersion("twistR")
 	cat(paste0("TWIST (Triangulation WIthin A STudy) analysis in R v", v, "\n"))
 	cat("- Linear model (continuous outcome)\n\n")

--- a/R/gmte_plot.R
+++ b/R/gmte_plot.R
@@ -4,7 +4,7 @@
 #'
 #' @param x An object of class \code{twistR_GMTE} e.g., the output from \code{gmte_continuous}
 #' @param plot_title A string to print as the plot title
-#' @param plot_cat Logical. Plot the CAT estimates? (Default=TRUE)
+#' @param plot_cat Logical. Plot the CAT estimates? (Default=FALSE)
 #' @param cols Three colours to indiciate the three model types (GMTE0, individual estimates, combined estimates)
 #' @param pchs Three point types to indiciate the three model types (GMTE0, individual estimates, combined estimates)
 #'
@@ -27,7 +27,7 @@
 
 gmte_plot = function(x, 
                      plot_title = "", 
-                     plot_cat = TRUE,
+                     plot_cat = FALSE,
                      cols = c("#f46036","#2e294e","#1b998b"),
                      pchs = c(15,16,23))  {
 

--- a/R/gmte_plot.R
+++ b/R/gmte_plot.R
@@ -42,7 +42,7 @@ gmte_plot = function(x,
 	res   = x$FullCombined
 
 	# is CAT in the object? 
-	if (grepl())  {
+	if ("CAT" %in% res_aalen$FullCombined$Model)  {
 	
 		## move CAT below other estimates
 		rownames(res)=c(6,1:5,7:10)
@@ -52,6 +52,9 @@ gmte_plot = function(x,
 		res[,"col"] = c(cols[1],cols[2],cols[2],cols[2],cols[3],cols[2],cols[3],cols[3],cols[3],cols[3])
 		res[,"pch"] = c(pchs[1],pchs[2],pchs[2],pchs[2],pchs[3],pchs[2],pchs[3],pchs[3],pchs[3],pchs[3])
 	
+		## if plotting CAT but it is 10* larger than other estimates give a warning.
+		if (abs(res[res[,"Model"]=="CAT","Est"]) > 10*max(abs(res[res[,"Model"] %in% c("GMTE0","GMTE1","RGMTE","MR","RGMTE_MR"),"Est"])))  warning("The CAT estimate is substantially larger than other estimates. Consider re-running with the flag 'plot_cat=FALSE'")
+		
 	} else {
 		
 		## add colours & point types
@@ -59,9 +62,6 @@ gmte_plot = function(x,
 		res[,"pch"] = c(pchs[1],pchs[2],pchs[2],pchs[2],pchs[3])
 		
 	}
-
-	## if plotting CAT but it is 10* larger than other estimates give a warning.
-	if (plot_cat & abs(res[res[,"Model"]=="CAT","Est"]) > 10*max(abs(res[res[,"Model"] %in% c("GMTE0","GMTE1","RGMTE","MR","RGMTE_MR"),"Est"])))  warning("The CAT estimate is substantially larger than other estimates. Consider re-running with the flag 'plot_cat=FALSE'")
 
 	## remove CAT estimate if specified by user
 	if (!plot_cat) res = res[ ! grepl("CAT",res[,"Model"]) , ]

--- a/R/gmte_plot.R
+++ b/R/gmte_plot.R
@@ -41,13 +41,24 @@ gmte_plot = function(x,
 	model = x$model
 	res   = x$FullCombined
 
-	## move CAT below other estimates
-	rownames(res)=c(6,1:5,7:10)
-	res=res[order(as.numeric(rownames(res))),]
-
-	## add colours & point types
-	res[,"col"] = c(cols[1],cols[2],cols[2],cols[2],cols[3],cols[2],cols[3],cols[3],cols[3],cols[3])
-	res[,"pch"] = c(pchs[1],pchs[2],pchs[2],pchs[2],pchs[3],pchs[2],pchs[3],pchs[3],pchs[3],pchs[3])
+	# is CAT in the object? 
+	if (grepl())  {
+	
+		## move CAT below other estimates
+		rownames(res)=c(6,1:5,7:10)
+		res=res[order(as.numeric(rownames(res))),]
+	
+		## add colours & point types
+		res[,"col"] = c(cols[1],cols[2],cols[2],cols[2],cols[3],cols[2],cols[3],cols[3],cols[3],cols[3])
+		res[,"pch"] = c(pchs[1],pchs[2],pchs[2],pchs[2],pchs[3],pchs[2],pchs[3],pchs[3],pchs[3],pchs[3])
+	
+	} else {
+		
+		## add colours & point types
+		res[,"col"] = c(cols[1],cols[2],cols[2],cols[2],cols[3])
+		res[,"pch"] = c(pchs[1],pchs[2],pchs[2],pchs[2],pchs[3])
+		
+	}
 
 	## if plotting CAT but it is 10* larger than other estimates give a warning.
 	if (plot_cat & abs(res[res[,"Model"]=="CAT","Est"]) > 10*max(abs(res[res[,"Model"] %in% c("GMTE0","GMTE1","RGMTE","MR","RGMTE_MR"),"Est"])))  warning("The CAT estimate is substantially larger than other estimates. Consider re-running with the flag 'plot_cat=FALSE'")

--- a/R/gmte_plot.R
+++ b/R/gmte_plot.R
@@ -42,7 +42,7 @@ gmte_plot = function(x,
 	res   = x$FullCombined
 
 	# is CAT in the object? 
-	if ("CAT" %in% res_aalen$FullCombined$Model)  {
+	if ("CAT" %in% res$FullCombined$Model)  {
 	
 		## move CAT below other estimates
 		rownames(res)=c(6,1:5,7:10)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 TWIST (Triangulation WIthin A STudy) analysis in R. 
 
 <!-- badges: start -->
-[![](https://img.shields.io/badge/version-0.1.4-informational.svg)](https://github.com/lcpilling/twistR)
+[![](https://img.shields.io/badge/version-0.1.4.9000-informational.svg)](https://github.com/lcpilling/twistR)
 [![](https://img.shields.io/github/last-commit/lcpilling/twistR.svg)](https://github.com/lcpilling/twistR/commits/master)
 [![](https://img.shields.io/badge/lifecycle-experimental-orange)](https://www.tidyverse.org/lifecycle/#experimental)
 [![DOI](https://zenodo.org/badge/402818137.svg)](https://zenodo.org/badge/latestdoi/402818137)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 TWIST (Triangulation WIthin A STudy) analysis in R. 
 
 <!-- badges: start -->
-[![](https://img.shields.io/badge/version-0.1.4.9000-informational.svg)](https://github.com/lcpilling/twistR)
+[![](https://img.shields.io/badge/version-0.1.5-informational.svg)](https://github.com/lcpilling/twistR)
 [![](https://img.shields.io/github/last-commit/lcpilling/twistR.svg)](https://github.com/lcpilling/twistR/commits/master)
 [![](https://img.shields.io/badge/lifecycle-experimental-orange)](https://www.tidyverse.org/lifecycle/#experimental)
 [![DOI](https://zenodo.org/badge/402818137.svg)](https://zenodo.org/badge/latestdoi/402818137)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,6 +1,7 @@
 url: https://lcpilling.github.io/twistR/
 template:
   bootstrap: 5
+  light-switch: true
 
 authors:
   Luke Pilling:

--- a/man/gmte_aalen.Rd
+++ b/man/gmte_aalen.Rd
@@ -14,6 +14,7 @@ gmte_aalen(
   D,
   Nsim = 100,
   alpha = 0.05,
+  doCAT = FALSE,
   verbose = FALSE
 )
 }
@@ -35,6 +36,8 @@ gmte_aalen(
 \item{Nsim}{Number of simulations to perform in the \code{aalen()} models. Default is 100.}
 
 \item{alpha}{The p-value threshold for the chi-square test, estimating whether two estimates should be combined. Default is 0.05.}
+
+\item{doCAT}{Run the CAT analysis? Default is FALSE.}
 
 \item{verbose}{Return lots of output - useful for error checking. Default is FALSE.}
 }

--- a/man/gmte_binary.Rd
+++ b/man/gmte_binary.Rd
@@ -4,7 +4,17 @@
 \alias{gmte_binary}
 \title{gmte_binary}
 \usage{
-gmte_binary(Y, T, G, Z, D, Link = "logit", alpha = 0.05, verbose = FALSE)
+gmte_binary(
+  Y,
+  T,
+  G,
+  Z,
+  D,
+  Link = "logit",
+  alpha = 0.05,
+  doCAT = FALSE,
+  verbose = FALSE
+)
 }
 \arguments{
 \item{Y}{The binary outcome variable name (string) which appears in data.frame \code{D}.}
@@ -20,6 +30,8 @@ gmte_binary(Y, T, G, Z, D, Link = "logit", alpha = 0.05, verbose = FALSE)
 \item{Link}{Link function for the \code{glm()} - needs to be one of "logit","probit" or "identity". If unspecified the default is "logit".}
 
 \item{alpha}{The p-value threshold for the chi-square test, estimating whether two estimates should be combined. Default is 0.05.}
+
+\item{doCAT}{Run the CAT analysis? Default is FALSE.}
 
 \item{verbose}{Return lots of output - useful for error checking. Default is FALSE.}
 }

--- a/man/gmte_continuous.Rd
+++ b/man/gmte_continuous.Rd
@@ -4,7 +4,7 @@
 \alias{gmte_continuous}
 \title{gmte_continuous}
 \usage{
-gmte_continuous(Y, T, G, Z, D, alpha = 0.05, verbose = FALSE)
+gmte_continuous(Y, T, G, Z, D, alpha = 0.05, doCAT = FALSE, verbose = FALSE)
 }
 \arguments{
 \item{Y}{The continuous outcome variable name (string) which appears in data.frame \code{D}.}
@@ -18,6 +18,8 @@ gmte_continuous(Y, T, G, Z, D, alpha = 0.05, verbose = FALSE)
 \item{D}{A data.frame containing the above variables.}
 
 \item{alpha}{The p-value threshold for the chi-square test, estimating whether two estimates should be combined. Default is 0.05.}
+
+\item{doCAT}{Run the CAT analysis? Default is FALSE.}
 
 \item{verbose}{Return lots of output - useful for error checking. Default is FALSE.}
 }

--- a/man/gmte_plot.Rd
+++ b/man/gmte_plot.Rd
@@ -7,7 +7,7 @@
 gmte_plot(
   x,
   plot_title = "",
-  plot_cat = TRUE,
+  plot_cat = FALSE,
   cols = c("#f46036", "#2e294e", "#1b998b"),
   pchs = c(15, 16, 23)
 )
@@ -17,7 +17,7 @@ gmte_plot(
 
 \item{plot_title}{A string to print as the plot title}
 
-\item{plot_cat}{Logical. Plot the CAT estimates? (Default=TRUE)}
+\item{plot_cat}{Logical. Plot the CAT estimates? (Default=FALSE)}
 
 \item{cols}{Three colours to indiciate the three model types (GMTE0, individual estimates, combined estimates)}
 


### PR DESCRIPTION
CAT analysis rarely useful due to strict assumptions. Default is now to not run it. Run it using `doCAT=TRUE`

Also changed URL to reflect my GitHub username change from `lukepilling` to `lcpilling` to be more consistent between different logins, websites, and social media
  * https://lcpilling.github.io/twistR
  * https://github.com/lcpilling/twistR
